### PR TITLE
Componentize

### DIFF
--- a/lib/scenic/fuel_gauge.ex
+++ b/lib/scenic/fuel_gauge.ex
@@ -16,15 +16,16 @@ defmodule Scenic.FuelGauge do
   """
 
   @doc false
-  def verify(name) when is_atom(name), do: {:ok, name}
+  def verify(%{name: name} = data) when is_atom(name), do: {:ok, data}
   def verify(_), do: :invalid_data
 
   @doc false
-  def init(name, opts) do
+  def init(%{name: name} = data, opts) do
     true = Process.register(self(), name)
+    fuel = Map.get(data, :fuel, 0.0)
     state = %{
       data: %{
-        fuel: 0.0,
+        fuel: fuel,
       },
       opts: opts
     }

--- a/lib/scenic/fuel_gauge/components.ex
+++ b/lib/scenic/fuel_gauge/components.ex
@@ -1,0 +1,40 @@
+defmodule Scenic.FuelGauge.Components do
+  alias Scenic.Graph
+  alias Scenic.Primitive
+  alias Scenic.FuelGauge
+
+  @moduledoc """
+  A helper to add a fuel gauge to a scene
+  """
+
+  @doc """
+  Add a guel gauge to a graph.
+
+  The only data you need to provide is a `name` you want the fuel gauge to register itself with.
+  This allows you to later send messages to the process updating the fuel level and label
+
+  ### Examples
+
+      graph
+      |> Scenic.FuelGauge.Components.fuel_gauge(:fuel_gauge, translate: {20, 20} )
+  """
+  def fuel_gauge(graph, name, options \\ [])
+
+  def fuel_gauge(%Graph{} = g, name, options) do
+    add_to_graph(g, FuelGauge, name, options)
+  end
+
+  def fuel_gauge(%Primitive{module: Primitive.SceneRef} = p, name, options) do
+    modify(p, FuelGauge, name, options)
+  end
+
+  defp add_to_graph(%Graph{} = g, mod, data, options) do
+    mod.verify!(data)
+    mod.add_to_graph(g, data, options)
+  end
+
+  defp modify(%Primitive{module: Primitive.SceneRef} = p, mod, data, options) do
+    mod.verify!(data)
+    Primitive.put(p, {mod, data}, options)
+  end
+end

--- a/lib/scenic/fuel_gauge/components.ex
+++ b/lib/scenic/fuel_gauge/components.ex
@@ -10,15 +10,15 @@ defmodule Scenic.FuelGauge.Components do
   @doc """
   Add a fuel gauge to a graph.
 
-  Make sure to pass in data as a map with a `:name` key.
-  The component will register itself with that name so you can later send fuel level updates.
-  You can also pass the `:fuel` key with a value betwen `0.0..1.0` to indicate the fuel leve.
-  To update this simply send a message to the registered name like `{:fuel, 0.75}`.
+  Make sure to pass in data as a map with a `:gauge_sensor_id` key.
+  The component will subscribe to sensor updates for the given `gauge_sensor_id`.
+  You can also pass the `:fuel` key with a value betwen `0.0..1.0` to indicate the initial fuel level.
+  To update this simply call `:ok = Scenic.Sensor.publish(:gauge_sensor_id, 0.75)`.
 
   ### Examples
 
       graph
-      |> Scenic.FuelGauge.Components.fuel_gauge(%{name: :fuel_gauge, fuel: 0.5}, translate: {20, 20} )
+      |> Scenic.FuelGauge.Components.fuel_gauge(%{gauge_sensor_id: :battery_level, fuel: 0.5}, translate: {20, 20} )
   """
   def fuel_gauge(graph, data, options \\ [])
 

--- a/lib/scenic/fuel_gauge/components.ex
+++ b/lib/scenic/fuel_gauge/components.ex
@@ -8,24 +8,26 @@ defmodule Scenic.FuelGauge.Components do
   """
 
   @doc """
-  Add a guel gauge to a graph.
+  Add a fuel gauge to a graph.
 
-  The only data you need to provide is a `name` you want the fuel gauge to register itself with.
-  This allows you to later send messages to the process updating the fuel level and label
+  Make sure to pass in data as a map with a `:name` key.
+  The component will register itself with that name so you can later send fuel level updates.
+  You can also pass the `:fuel` key with a value betwen `0.0..1.0` to indicate the fuel leve.
+  To update this simply send a message to the registered name like `{:fuel, 0.75}`.
 
   ### Examples
 
       graph
-      |> Scenic.FuelGauge.Components.fuel_gauge(:fuel_gauge, translate: {20, 20} )
+      |> Scenic.FuelGauge.Components.fuel_gauge(%{name: :fuel_gauge, fuel: 0.5}, translate: {20, 20} )
   """
-  def fuel_gauge(graph, name, options \\ [])
+  def fuel_gauge(graph, data, options \\ [])
 
-  def fuel_gauge(%Graph{} = g, name, options) do
-    add_to_graph(g, FuelGauge, name, options)
+  def fuel_gauge(%Graph{} = g, data, options) do
+    add_to_graph(g, FuelGauge, data, options)
   end
 
-  def fuel_gauge(%Primitive{module: Primitive.SceneRef} = p, name, options) do
-    modify(p, FuelGauge, name, options)
+  def fuel_gauge(%Primitive{module: Primitive.SceneRef} = p, data, options) do
+    modify(p, FuelGauge, data, options)
   end
 
   defp add_to_graph(%Graph{} = g, mod, data, options) do

--- a/mix.exs
+++ b/mix.exs
@@ -35,6 +35,7 @@ defmodule ScenicFuelGauge.MixProject do
   defp deps do
     [
       {:scenic, "~> 0.10"},
+      {:scenic_sensor, "~> 0.7"},
       {:ex_doc, ">= 0.0.0", only: [:dev, :docs]}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -8,4 +8,5 @@
   "msgpax": {:hex, :msgpax, "2.2.4", "7b3790ef684089076b63c0f08c2f4b079c6311daeb006b69e4ed2bf67518291e", [:mix], [{:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: true]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm"},
   "scenic": {:hex, :scenic, "0.10.2", "f4f0a00eed677ac50a7b297375c0323d03f4273580f17c50b877abfaf0c6dc1f", [:make, :mix], [{:elixir_make, "~> 0.5", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:font_metrics, "~> 0.3", [hex: :font_metrics, repo: "hexpm", optional: false]}], "hexpm"},
+  "scenic_sensor": {:hex, :scenic_sensor, "0.7.0", "a12aed7596fbab025a535f912325da5a087ff704e96f7acb274c3034d832f9ce", [:mix], [], "hexpm"},
 }

--- a/test/fuel_gauge_test.exs
+++ b/test/fuel_gauge_test.exs
@@ -8,10 +8,13 @@ defmodule Scenic.FuelGaugeTest do
   }
 
   test "init" do
-    {:ok, _, push: _} = FuelGauge.init(%{name: :test_name}, styles: %{})
+    {:ok, _, push: _} = FuelGauge.init(%{gauge_sensor_id: :test_name}, styles: %{})
   end
 
   test "handle_info {:fuel, level}" do
-    assert {:noreply, state, push: _} = FuelGauge.handle_info({:fuel, 0.5}, @state)
+    timestamp = :os.system_time(:micro_seconds)
+    sensor_message = {:sensor, :data, {:test_name, 0.5, timestamp}}
+    assert {:noreply, new_state, push: _} = FuelGauge.handle_info(sensor_message, @state)
+    assert new_state.data.fuel == 0.5
   end
 end

--- a/test/fuel_gauge_test.exs
+++ b/test/fuel_gauge_test.exs
@@ -8,7 +8,7 @@ defmodule Scenic.FuelGaugeTest do
   }
 
   test "init" do
-    {:ok, _, push: _} = FuelGauge.init(:test_name, styles: %{})
+    {:ok, _, push: _} = FuelGauge.init(%{name: :test_name}, styles: %{})
   end
 
   test "handle_info {:fuel, level}" do

--- a/test/fuel_gauge_test.exs
+++ b/test/fuel_gauge_test.exs
@@ -1,9 +1,17 @@
 defmodule Scenic.FuelGaugeTest do
   use ExUnit.Case
-  doctest Scenic.FuelGauge
+  alias Scenic.FuelGauge
 
-  test "draws itself onto a graph" do
-    graph = Scenic.Graph.build() |> Scenic.FuelGauge.draw(%{fuel: 0.5})
-    assert %Scenic.Graph{} = graph
+  @state %{
+    data: %{fuel: 0.5},
+    opts: %{styles: %{font: :roboto, font_size: 24}}
+  }
+
+  test "init" do
+    {:ok, _, push: _} = FuelGauge.init(:test_name, styles: %{})
+  end
+
+  test "handle_info {:fuel, level}" do
+    assert {:noreply, state, push: _} = FuelGauge.handle_info({:fuel, 0.5}, @state)
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
 ExUnit.start()
+
+{:ok, _pid} = Scenic.Sensor.start_link(nil)


### PR DESCRIPTION
@boydm suggested that [this should be a component](https://twitter.com/ScenicFramework/status/1189646397147992064)

This PR attempts to "componentize" the fuel gauge. I wasn't sure about how it should get updated, so this first pass asks the user to pass in a `:name` data key that the component will register itself under. Then later the user can just `send :fuel_gauge, {:fuel, 0.5}` to update the fuel level.

This will break things for @pressy4pie, but hopefully it puts us on a good track and we can add things like optional labels next.